### PR TITLE
Use `crypto.PrivateKey` instead of `*rsa.PrivateKey` where possible

### DIFF
--- a/scep.go
+++ b/scep.go
@@ -198,7 +198,7 @@ type PKIMessage struct {
 	Recipients []*x509.Certificate
 
 	// Signer info
-	SignerKey  *rsa.PrivateKey
+	SignerKey  crypto.PrivateKey
 	SignerCert *x509.Certificate
 
 	logger Logger

--- a/scep.go
+++ b/scep.go
@@ -344,7 +344,17 @@ func (msg *PKIMessage) parseMessageType() error {
 }
 
 // DecryptPKIEnvelope decrypts the pkcs envelopedData inside the SCEP PKIMessage
-func (msg *PKIMessage) DecryptPKIEnvelope(cert *x509.Certificate, key *rsa.PrivateKey) error {
+func (msg *PKIMessage) DecryptPKIEnvelope(cert *x509.Certificate, key crypto.Decrypter) error {
+	if cert == nil {
+		return errors.New("scep: cert must not be nil")
+	}
+	if key == nil {
+		return errors.New("scep: key must not be nil")
+	}
+	if _, ok := key.Public().(*rsa.PublicKey); !ok {
+		return fmt.Errorf("scep: key.Public() returned type %T; expected *rsa.PublicKey", key.Public())
+	}
+
 	p7, err := pkcs7.Parse(msg.p7.Content)
 	if err != nil {
 		return err

--- a/scep_test.go
+++ b/scep_test.go
@@ -104,18 +104,24 @@ func TestDecryptPKIEnvelopeDecrypter(t *testing.T) {
 		t.Fatal("expected error on nil key")
 	}
 
-	if err := msg.DecryptPKIEnvelope(cacert, &fakeDecrypter{}); err == nil {
+	if err := msg.DecryptPKIEnvelope(cacert, &notADecrypter{}); err == nil {
 		t.Fatal("expected error on invalid decrypter")
+	}
+
+	if err := msg.DecryptPKIEnvelope(cacert, &nonRSADecrypter{}); err == nil {
+		t.Fatal("expected error on non-RSA decrypter")
 	}
 }
 
-type fakeDecrypter struct{}
+type notADecrypter struct{}
 
-func (f *fakeDecrypter) Public() crypto.PublicKey {
+type nonRSADecrypter struct{}
+
+func (d *nonRSADecrypter) Public() crypto.PublicKey {
 	return struct{}{}
 }
 
-func (f *fakeDecrypter) Decrypt(rand io.Reader, msg []byte, opts crypto.DecrypterOpts) (plaintext []byte, err error) {
+func (d *nonRSADecrypter) Decrypt(rand io.Reader, msg []byte, opts crypto.DecrypterOpts) (plaintext []byte, err error) {
 	return nil, nil
 }
 

--- a/scep_test.go
+++ b/scep_test.go
@@ -121,8 +121,8 @@ func (d *nonRSADecrypter) Public() crypto.PublicKey {
 	return struct{}{}
 }
 
-func (d *nonRSADecrypter) Decrypt(rand io.Reader, msg []byte, opts crypto.DecrypterOpts) (plaintext []byte, err error) {
-	return nil, nil
+func (d *nonRSADecrypter) Decrypt(_ io.Reader, _ []byte, _ crypto.DecrypterOpts) (plaintext []byte, err error) {
+	return nil, errors.New("not implemented")
 }
 
 func TestDecryptPKIEnvelopeCert(t *testing.T) {

--- a/x509util/x509util.go
+++ b/x509util/x509util.go
@@ -55,7 +55,7 @@ type CertificateRequest struct {
 // challengePassword attribute.
 //
 // See https://github.com/golang/go/issues/15995
-func CreateCertificateRequest(rand io.Reader, template *CertificateRequest, priv interface{}) (csr []byte, err error) {
+func CreateCertificateRequest(rand io.Reader, template *CertificateRequest, priv crypto.PrivateKey) (csr []byte, err error) {
 	if template.ChallengePassword == "" {
 		// if no challenge password, return a stdlib CSR.
 		return x509.CreateCertificateRequest(rand, &template.CertificateRequest, priv)


### PR DESCRIPTION
This PR closes #13 