### PR TITLE
remove go-kit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,4 @@ module github.com/smallstep/scep
 
 go 1.16
 
-require (
-	github.com/go-kit/kit v0.4.0
-	github.com/smallstep/pkcs7 v0.0.0-20231024181729-3b98ecc1ca81
-)
-
-require (
-	github.com/go-logfmt/logfmt v0.5.1 // indirect
-	github.com/go-stack/stack v1.6.0 // indirect
-)
+require github.com/smallstep/pkcs7 v0.0.0-20231024181729-3b98ecc1ca81

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,2 @@
-github.com/go-kit/kit v0.4.0 h1:KeVK+Emj3c3S4eRztFuzbFYb2BAgf2jmwDwyXEri7Lo=
-github.com/go-kit/kit v0.4.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
-github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
-github.com/go-stack/stack v1.6.0 h1:MmJCxYVKTJ0SplGKqFVX3SBnmaUhODHZrrFF6jMbpZk=
-github.com/go-stack/stack v1.6.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/smallstep/pkcs7 v0.0.0-20231024181729-3b98ecc1ca81 h1:B6cED3iLJTgxpdh4tuqByDjRRKan2EvtnOfHr2zHJVg=
 github.com/smallstep/pkcs7 v0.0.0-20231024181729-3b98ecc1ca81/go.mod h1:SoUAr/4M46rZ3WaLstHxGhLEgoYIDRqxQEXLOmOEB0Y=

--- a/scep.go
+++ b/scep.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/go-kit/kit/log/level"
 	"github.com/smallstep/pkcs7"
 
 	"github.com/smallstep/scep/cryptoutil"
@@ -25,12 +24,6 @@ import (
 var (
 	errNotImplemented     = errors.New("scep: not implemented")
 	errUnknownMessageType = errors.New("scep: unknown messageType")
-)
-
-// prepare the go-kit leveled logging configuration
-var (
-	levelKey   = level.Key()
-	levelDebug = level.DebugValue()
 )
 
 // The MessageType attribute specifies the type of operation performed
@@ -276,7 +269,6 @@ func ParsePKIMessage(data []byte, opts ...Option) (*PKIMessage, error) {
 	}
 
 	msg.logger.Log(
-		levelKey, levelDebug,
 		"msg", "parsed scep pkiMessage",
 		"scep_message_type", msgType,
 		"transaction_id", tID,
@@ -369,7 +361,6 @@ func (msg *PKIMessage) DecryptPKIEnvelope(cert *x509.Certificate, key crypto.Pri
 	}
 
 	logKeyVals := []interface{}{
-		levelKey, levelDebug,
 		"msg", "decrypt pkiEnvelope",
 	}
 	defer func() { msg.logger.Log(logKeyVals...) }()
@@ -613,7 +604,6 @@ func NewCSRRequest(csr *x509.CertificateRequest, tmpl *PKIMessage, opts ...Optio
 	}
 
 	conf.logger.Log(
-		levelKey, levelDebug,
 		"msg", "creating SCEP CSR request",
 		"transaction_id", tID,
 		"signer_cn", tmpl.SignerCert.Subject.CommonName,

--- a/scep_test.go
+++ b/scep_test.go
@@ -16,17 +16,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
-
 	"github.com/smallstep/scep/cryptoutil"
 )
 
 func testParsePKIMessage(t *testing.T, data []byte) *PKIMessage {
 	t.Helper()
 
-	logger := log.NewLogfmtLogger(os.Stderr)
-	logger = level.NewFilter(logger, level.AllowDebug())
+	logger := newNopLogger()
 	msg, err := ParsePKIMessage(data, WithLogger(logger))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
#### Name of feature:

Remove go-kit dependency. See #18. Tests still pass.

#### Pain or issue this feature alleviates:

Technically unnecessary dependency and reduces go.sum bloat.
