### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,4 +26,5 @@ jobs:
     with:
       run-build: false
       run-codeql: true
+      codeql-build-cmd: 'go build ./...'
     secrets: inherit

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,7 @@ jobs:
       security-events: write
     uses: smallstep/workflows/.github/workflows/goCI.yml@main
     with:
+      run-lint: false
       run-build: false
       run-codeql: true
       codeql-build-cmd: 'go build ./...'


### PR DESCRIPTION
https://github.com/smallstep/scep/pull/28 broke CI.

Currently this repo supports Go versions back to 1.16. When setting up Go for the linter the 1.16 version gets selected based on the `go.mod`. This breaks the linter, because the `-buildvcs` flag is not available.

We opt to disable linting (for now). It can be run locally, and given that this repo doesn't see a lot of activity at the moment, I think that can be OK for this case. Alternatives would be to use an older version of the linter, up the minimum Go version (minimum, I believe 1.18?), or have some option to wire through configuration of the Go version to select for a specific step.