### PR TITLE
Fix lint warnings in scep and x509util

### DIFF
--- a/scep.go
+++ b/scep.go
@@ -268,7 +268,7 @@ func ParsePKIMessage(data []byte, opts ...Option) (*PKIMessage, error) {
 		logger:        conf.logger,
 	}
 
-	msg.logger.Log(
+	_ = msg.logger.Log(
 		"msg", "parsed scep pkiMessage",
 		"scep_message_type", msgType,
 		"transaction_id", tID,
@@ -363,7 +363,7 @@ func (msg *PKIMessage) DecryptPKIEnvelope(cert *x509.Certificate, key crypto.Pri
 	logKeyVals := []interface{}{
 		"msg", "decrypt pkiEnvelope",
 	}
-	defer func() { msg.logger.Log(logKeyVals...) }()
+	defer func() { _ = msg.logger.Log(logKeyVals...) }()
 
 	switch msg.MessageType {
 	case CertRep:
@@ -371,7 +371,7 @@ func (msg *PKIMessage) DecryptPKIEnvelope(cert *x509.Certificate, key crypto.Pri
 		if err != nil {
 			return err
 		}
-		msg.CertRepMessage.Certificate = certs[0]
+		msg.Certificate = certs[0]
 		logKeyVals = append(logKeyVals, "ca_certs", len(certs))
 		return nil
 	case PKCSReq, UpdateReq, RenewalReq:
@@ -464,7 +464,7 @@ func (msg *PKIMessage) Fail(crtAuth *x509.Certificate, keyAuth crypto.PrivateKey
 // Success returns a new PKIMessage with CertRep data using an already-issued certificate
 func (msg *PKIMessage) Success(crtAuth *x509.Certificate, keyAuth crypto.PrivateKey, crt *x509.Certificate) (*PKIMessage, error) {
 	// check if CSRReqMessage has already been decrypted
-	if msg.CSRReqMessage.CSR == nil { // TODO(hslatman): remove this; just require decryption before, so that we can make keyAuth a crypto.Signer
+	if msg.CSR == nil { // TODO(hslatman): remove this; just require decryption before, so that we can make keyAuth a crypto.Signer
 		if err := msg.DecryptPKIEnvelope(crtAuth, keyAuth); err != nil {
 			return nil, err
 		}
@@ -603,7 +603,7 @@ func NewCSRRequest(csr *x509.CertificateRequest, tmpl *PKIMessage, opts ...Optio
 		return nil, err
 	}
 
-	conf.logger.Log(
+	_ = conf.logger.Log(
 		"msg", "creating SCEP CSR request",
 		"transaction_id", tID,
 		"signer_cn", tmpl.SignerCert.Subject.CommonName,

--- a/scep_test.go
+++ b/scep_test.go
@@ -157,7 +157,7 @@ func TestDecryptPKIEnvelopeCSR(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if msg.CSRReqMessage.CSR == nil {
+	if msg.CSR == nil {
 		t.Errorf("expected non-nil CSR field")
 	}
 }
@@ -214,7 +214,7 @@ func TestSignCSR(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	csr := msg.CSRReqMessage.CSR
+	csr := msg.CSR
 	id, err := cryptoutil.GenerateSubjectKeyID(csr.PublicKey)
 	if err != nil {
 		t.Fatal(err)

--- a/x509util/x509util.go
+++ b/x509util/x509util.go
@@ -67,7 +67,7 @@ func CreateCertificateRequest(rand io.Reader, template *CertificateRequest, priv
 	// add the challenge attribute to the CSR, then re-sign the raw csr.
 	// not checking the crypto.Signer assertion because x509.CreateCertificateRequest already did that.
 	return addChallenge(
-		template.CertificateRequest.SignatureAlgorithm,
+		template.SignatureAlgorithm,
 		rand,
 		derBytes,
 		template.ChallengePassword,


### PR DESCRIPTION
Discard ignored return values from logger.Log calls (errcheck) and simplify embedded-field selectors to use promoted fields directly (staticcheck QF1008).

Change-Type: lint
Release-Note: no
Audience: internal
Impact: none
Breaking: false

